### PR TITLE
ENH: Upgrade Streamlit

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,9 +5,8 @@ import urllib
 import streamlit as st
 import utils
 
-# Define title and sidebar
-
-st.title("NYC Restaurant Violations")
+# Define header
+st.header('NYC Restaurant Violations')
 
 name = st.sidebar.text_input("Restaurant Name:", "")
 name = name.strip().upper()
@@ -18,6 +17,10 @@ street = street.strip().upper()
 boro = st.sidebar.selectbox(
     "Borough:", ["", "Manhattan", "Queens", "Brooklyn", "Staten Island", "Bronx"]
 )
+
+# Define subheader
+if boro:
+    st.subheader(boro)
 
 st.sidebar.markdown(
     """

--- a/app.py
+++ b/app.py
@@ -101,11 +101,25 @@ else:
             )
             for _, row in choices.iterrows()
         ]
+
+        # Pagination with buttons
+        display_limit = 15
+        num_pages = (len(choices) + display_limit - 1) // display_limit
+
+        # Display page selector before radio button list
+        page = st.number_input("Select Page", 1, num_pages, 1)
+
+        # Calculate the range of choices to display for the selected page
+        start_index = (page - 1) * display_limit
+        end_index = min(start_index + display_limit, len(choices))
+        display_choices = choices[start_index:end_index]
+
+        # Display the choices
         selected_str = st.radio(
             "You're probably looking for one of these restaurants, right?",
-            [s for _, s in choices],
+            [s for _, s in display_choices],
         )
-        selected_camis = [camis for camis, s in choices if s == selected_str]
+        selected_camis = [camis for camis, s in display_choices if s == selected_str]
         filtered = df.query(f"CAMIS == {selected_camis}")
         st.write("---")
         utils.write_violations(filtered)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pandas==2.2.0
-streamlit==1.30.0
+streamlit==1.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas==1.2.0
-streamlit==0.74.1
+pandas==2.2.0
+streamlit==1.30.0

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ import pandas as pd
 import streamlit as st
 
 
-@st.cache(persist=True)
+@st.cache_data(persist=True)
 def get_restaurant_violation_data():
     """ Read CSV from NYC Open Data website. """
     CSV_URL = (

--- a/utils.py
+++ b/utils.py
@@ -48,10 +48,13 @@ def summarize_violation_description(s):
 
 def write_violations(violations):
     first_row = violations.iloc[0]  # Just get the first row
-    st.header(
-        normalize(
-            f"{first_row['DBA']} ({first_row['BUILDING']} {first_row['STREET']}, {first_row['BORO']})"
-        )
+
+    # Display restaurant DBA as header
+    st.header(normalize(first_row['DBA']))
+
+    # Display building, street, and boro as a subheader on a new line
+    st.subheader(
+        f"{normalize(first_row['BUILDING'])} {normalize(first_row['STREET'])}, {normalize(first_row['BORO'])}"
     )
 
     violations.loc[:, "INSPECTION DATE"] = pd.to_datetime(


### PR DESCRIPTION
Streamlit: upgraded to [1.31.0](https://github.com/streamlit/streamlit/releases/tag/1.31.0)
- [st.cache](https://docs.streamlit.io/library/api-reference/performance/st.cache) deprecated; replaced with [st.cache_data](https://docs.streamlit.io/library/api-reference/performance/st.cache_data)

Pandas: bumped from 1.2.0 to [2.0.2](https://github.com/streamlit/streamlit/releases/tag/1.30.0)

Page element changes:
- App _title_ is now a _header_
- Basic page selector added
- Borough selected in sidebar is displayed as _sub-header_
- Restaurant selected (DBA) is now a _header_
  - Street and borough are _sub-header_

<img width="479" alt="Screenshot 2024-01-27 at 3 20 59 PM" src="https://github.com/eigenfoo/nyc-restaurant-violations/assets/1088664/a16d432d-2087-4862-a053-498c68b70fcb">
